### PR TITLE
Fixed over midnight flights

### DIFF
--- a/src/main/kotlin/controller/SiriEtDebugController.kt
+++ b/src/main/kotlin/controller/SiriEtDebugController.kt
@@ -23,7 +23,7 @@ class SiriEtDebugController(
      */
     @GetMapping("/siri", produces = [MediaType.APPLICATION_XML_VALUE])
     fun siriAllAirportsEndpoint(): String {
-        val unifiedFlights = flightAggregationService.fetchUnifiedFlights()
+        val unifiedFlights = flightAggregationService.buildUnifiedFlights()
         val resolved = serviceJourneyResolver.resolve(unifiedFlights)
         val siri = siriETMapper.mapUnifiedFlightsToSiri(resolved)
         return siriETPublisher.toXml(siri)

--- a/src/main/kotlin/service/FlightAggregationService.kt
+++ b/src/main/kotlin/service/FlightAggregationService.kt
@@ -51,9 +51,11 @@ class FlightAggregationService(
 
 
     /**
-     * Fetches flight data from all airports and stitches records into UnifiedFlight chains.
-     * Handles both direct (2 stops) and multi-leg (3+ stops) flights, including Svalbard routes.
-     * Used by the /siri endpoint.
+     * Orchestrates the pipeline to produce [UnifiedFlight] chains from Avinor data
+     * Fetches flight data from all airports, groups them by flightID and date. Stitches groups into ordered flight chain
+     * and filters these to allowed time window.
+     * Handles both direct (2 stops), multi-leg (3+ stops) and circular flights, including Svalbard routes.     *
+     * @return A list of [UnifiedFlight] objects representing all valid flight chains within allowed time window.
      */
     fun buildUnifiedFlights(): List<UnifiedFlight> = runBlocking {
         val airportCodes = AirportIATA.entries.map { it.name }
@@ -91,7 +93,12 @@ class FlightAggregationService(
     )
 
     /**
-     * FETCH: Collect all domestic (+ Svalbard) flights with their parsed schedule times
+     * Fetches all flights from [airportCodes] concurrently in batches, filters to domestic and Svalbard flights only.
+     * Wraps each result as [TaggedFlight] paring raw [Flight] record to parsed schedule time and source airport.
+     * Flights with no parsable/malformed schedule time are skipped with a warning.
+     *
+     * @param airportCodes The IATA codes of the airports to fetch flights from.
+     * @return All valid tagged flights across all airports.
      */
     private suspend fun fetchTaggedFlights(airportCodes: List<String>): List<TaggedFlight> {
         val result = mutableListOf<TaggedFlight>()
@@ -162,9 +169,14 @@ class FlightAggregationService(
         return sourceAirport == FlightCodes.SVALBARD_AIRPORTS || flight.airport == FlightCodes.SVALBARD_AIRPORTS
     }
 
-    /** GROUP: by flightId, then split on gaps > 6 hours to separate consecutive-day flights
-    with the same ID. Use the Oslo date of the first event in each sub-group as the anchor,
-    so legs that cross midnight Oslo (e.g. 23:50 dep → 00:10 arr) stay in the same group. */
+    /** Groups [TaggedFlight] by flightId, then split on time gaps greater than 6 hours.
+     * This separates flights sharing the same ID across consecutive days.
+     * The Oslo date of the first event in the sub-groups are used as the anchor keeping legs crossing midnight in same group.
+     * Avinor reuses flight IDs for the same route on different days, so grouping by flightId alone would mix together
+     *
+     * @param allTaggedFlights The list of all tagged flights to group.
+     * @return A map of [FlightKey] (flightID + anchorDate) to events belonging to the flight.
+     */
     private fun groupFlightsByIdAndDate(allTaggedFlights: List<TaggedFlight>): Map<FlightKey, List<TaggedFlight>> {
         val byFlightId = allTaggedFlights.groupBy { it.raw.flightId ?: "UNKNOWN" }
 

--- a/src/main/kotlin/service/FlightAggregationService.kt
+++ b/src/main/kotlin/service/FlightAggregationService.kt
@@ -83,6 +83,45 @@ class FlightAggregationService(
     )
 
     /**
+     * FETCH: Collect all domestic (+ Svalbard) flights with their parsed schedule times
+     */
+    private suspend fun fetchTaggedFlights(airportCodes: List<String>): List<TaggedFlight> {
+        val result = mutableListOf<TaggedFlight>()
+
+        airportCodes.chunked(PollingConfig.BATCH_SIZE).forEach { batch ->
+            coroutineScope {
+                batch.map { code ->
+                    async(ioDispatcher) {
+                        delay(PollingConfig.REQUEST_DELAY_MS.toLong())
+                        code to fetchFlightsForAirport(code)
+                    }
+                }.awaitAll()
+            }.forEach { (code, flights) ->
+                flights
+                    .filter { isDomesticOrSvalbard(code, it) }
+                    .forEach { flight ->
+                        try {
+                            parseTime(flight.scheduleTime)?.let { parsedTime ->
+                                result.add(TaggedFlight(code, flight, parsedTime))
+                            }
+                        } catch (e: Exception) {
+                            LOG.warn(
+                                "Malformed schedule time for flight {} at {}: {}",
+                                flight.flightId,
+                                code,
+                                e.message
+                            )
+                        }
+                    }
+            }
+        }
+        return result
+    }
+
+
+
+
+    /**
      * Fetches flight data from all airports and stitches records into UnifiedFlight chains.
      * Handles both direct (2 stops) and multi-leg (3+ stops) flights, including Svalbard routes.
      * Used by the /siri endpoint.
@@ -99,29 +138,7 @@ class FlightAggregationService(
 
         LOG.info("Starting unified flight fetch for {} airports...", airportCodes.size)
 
-        // FETCH: Collect all domestic (+ Svalbard) flights with their parsed schedule times
-        airportCodes.chunked(PollingConfig.BATCH_SIZE).forEach { batch ->
-            coroutineScope {
-                batch.map { code ->
-                    async(ioDispatcher) {
-                        delay(PollingConfig.REQUEST_DELAY_MS.toLong())
-                        code to fetchFlightsForAirport(code)
-                    }
-                }.awaitAll()
-            }.forEach { (code, flights) ->
-                flights
-                    .filter { isDomesticOrSvalbard(code, it) }
-                    .forEach { flight ->
-                        try {
-                            parseTime(flight.scheduleTime)?.let { parsedTime ->
-                                allTaggedFlights.add(TaggedFlight(code, flight, parsedTime))
-                            }
-                        } catch (e: Exception) {
-                            LOG.warn("Malformed schedule time for flight {} at {}: {}", flight.flightId, code, e.message)
-                        }
-                    }
-            }
-        }
+
 
 
         // GROUP: by flightId, then split on gaps > 6 hours to separate consecutive-day flights

--- a/src/main/kotlin/service/FlightAggregationService.kt
+++ b/src/main/kotlin/service/FlightAggregationService.kt
@@ -118,7 +118,30 @@ class FlightAggregationService(
         return result
     }
 
+    /** GROUP: by flightId, then split on gaps > 6 hours to separate consecutive-day flights
+    with the same ID. Use the Oslo date of the first event in each sub-group as the anchor,
+    so legs that cross midnight Oslo (e.g. 23:50 dep → 00:10 arr) stay in the same group. */
+    private fun groupFlightsByIdAndDate(allTaggedFlights: List<TaggedFlight>): Map<FlightKey, List<TaggedFlight>> {
+        val byFlightId = allTaggedFlights.groupBy { it.raw.flightId ?: "UNKNOWN" }
 
+        return buildMap {
+            for ((flightId, events) in byFlightId) {
+                val sorted = events.sortedBy { it.time }
+                var subGroup = mutableListOf(sorted.first())
+
+                for (i in 1 until sorted.size) {
+                    if (Duration.between(sorted[i - 1].time, sorted[i].time) > Duration.ofHours(6)) {
+                        val anchorDate = subGroup.first().time.atZone(ZoneId.of("Europe/Oslo")).toLocalDate()
+                        put(FlightKey(flightId, anchorDate), subGroup)
+                        subGroup = mutableListOf()
+                    }
+                    subGroup.add(sorted[i])
+                }
+                val anchorDate = subGroup.first().time.atZone(ZoneId.of("Europe/Oslo")).toLocalDate()
+                put(FlightKey(flightId, anchorDate), subGroup)
+            }
+        }
+    }
 
 
     /**
@@ -137,31 +160,6 @@ class FlightAggregationService(
         val allTaggedFlights = mutableListOf<TaggedFlight>()
 
         LOG.info("Starting unified flight fetch for {} airports...", airportCodes.size)
-
-
-
-
-        // GROUP: by flightId, then split on gaps > 6 hours to separate consecutive-day flights
-        // with the same ID. Use the Oslo date of the first event in each sub-group as the anchor,
-        // so legs that cross midnight Oslo (e.g. 23:50 dep → 00:10 arr) stay in the same group.
-        val byFlightId = allTaggedFlights.groupBy { it.raw.flightId ?: "UNKNOWN" }
-        val grouped = buildMap<FlightKey, List<TaggedFlight>> {
-            for ((flightId, events) in byFlightId) {
-                val sorted = events.sortedBy { it.time }
-                var subGroup = mutableListOf(sorted.first())
-
-                for (i in 1 until sorted.size) {
-                    if (Duration.between(sorted[i - 1].time, sorted[i].time) > Duration.ofHours(6)) {
-                        val anchorDate = subGroup.first().time.atZone(ZoneId.of("Europe/Oslo")).toLocalDate()
-                        put(FlightKey(flightId, anchorDate), subGroup)
-                        subGroup = mutableListOf()
-                    }
-                    subGroup.add(sorted[i])
-                }
-                val anchorDate = subGroup.first().time.atZone(ZoneId.of("Europe/Oslo")).toLocalDate()
-                put(FlightKey(flightId, anchorDate), subGroup)
-            }
-        }
 
 
         // STITCH: convert each group into an ordered chain of stops

--- a/src/main/kotlin/service/FlightAggregationService.kt
+++ b/src/main/kotlin/service/FlightAggregationService.kt
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory
 import org.gibil.model.AirportIATA
 import org.springframework.stereotype.Service
 import util.DateUtil.parseTime
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -122,10 +123,29 @@ class FlightAggregationService(
             }
         }
 
-        // GROUP: by flightId + date to avoid mixing flights from different days
-        val grouped = allTaggedFlights.groupBy {
-            FlightKey(it.raw.flightId ?: "UNKNOWN", it.time.atZone(ZoneId.of("Europe/Oslo")).toLocalDate())
+
+        // GROUP: by flightId, then split on gaps > 6 hours to separate consecutive-day flights
+        // with the same ID. Use the Oslo date of the first event in each sub-group as the anchor,
+        // so legs that cross midnight Oslo (e.g. 23:50 dep → 00:10 arr) stay in the same group.
+        val byFlightId = allTaggedFlights.groupBy { it.raw.flightId ?: "UNKNOWN" }
+        val grouped = buildMap<FlightKey, List<TaggedFlight>> {
+            for ((flightId, events) in byFlightId) {
+                val sorted = events.sortedBy { it.time }
+                var subGroup = mutableListOf(sorted.first())
+
+                for (i in 1 until sorted.size) {
+                    if (Duration.between(sorted[i - 1].time, sorted[i].time) > Duration.ofHours(6)) {
+                        val anchorDate = subGroup.first().time.atZone(ZoneId.of("Europe/Oslo")).toLocalDate()
+                        put(FlightKey(flightId, anchorDate), subGroup)
+                        subGroup = mutableListOf()
+                    }
+                    subGroup.add(sorted[i])
+                }
+                val anchorDate = subGroup.first().time.atZone(ZoneId.of("Europe/Oslo")).toLocalDate()
+                put(FlightKey(flightId, anchorDate), subGroup)
+            }
         }
+
 
         // STITCH: convert each group into an ordered chain of stops
         val unifiedFlights = grouped.mapNotNull { (key, events) ->

--- a/src/main/kotlin/service/FlightAggregationService.kt
+++ b/src/main/kotlin/service/FlightAggregationService.kt
@@ -13,6 +13,7 @@ import model.UnifiedFlight
 import model.xmlFeedApi.Flight
 import org.gibil.util.Dates
 import org.gibil.util.FlightCodes
+import org.gibil.util.FlightWindowConfig
 import org.gibil.util.PollingConfig
 import org.gibil.routes.avinor.xmlfeed.AvinorXmlFeedApiHandler
 import org.gibil.routes.avinor.xmlfeed.AvinorXmlFeedParamsLogic
@@ -23,7 +24,6 @@ import util.DateUtil.parseTime
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
@@ -41,13 +41,6 @@ class FlightAggregationService(
     private val xmlHandler: AvinorScheduleXmlHandler,
     private val ioDispatcher: CoroutineDispatcher
 ) {
-
-
-    companion object {
-        // Filter to only include flights within this time window
-        const val MAX_PAST_MINUTES = 20L      // At most 20 minutes in the past
-        const val MAX_FUTURE_HOURS = 24L       // Up to 7 hours in the future
-    }
 
 
     /**
@@ -73,8 +66,7 @@ class FlightAggregationService(
 
         // STITCH: convert each group into an ordered chain of stops
         val unifiedFlights = groupedTaggedFlights.mapNotNull { (key, events) ->
-            if(key.flightId == "UNKNOWN") null
-            else stitchFlightLegs(key.flightId, key.date, events)
+            stitchFlightLegs(key.flightId, key.date, events)
         }
 
         val filteredChains = unifiedFlights.filter { isChainWithinTimeWindow(it, Dates.instantNowUtc()) }
@@ -178,7 +170,9 @@ class FlightAggregationService(
      * @return A map of [FlightKey] (flightID + anchorDate) to events belonging to the flight.
      */
     private fun groupFlightsByIdAndDate(allTaggedFlights: List<TaggedFlight>): Map<FlightKey, List<TaggedFlight>> {
-        val byFlightId = allTaggedFlights.groupBy { it.raw.flightId ?: "UNKNOWN" }
+        val byFlightId = allTaggedFlights
+            .filter { it.raw.flightId != null }
+            .groupBy { it.raw.flightId!! }
 
         return buildMap {
             for ((flightId, events) in byFlightId) {
@@ -186,14 +180,14 @@ class FlightAggregationService(
                 var subGroup = mutableListOf(sorted.first())
 
                 for (i in 1 until sorted.size) {
-                    if (Duration.between(sorted[i - 1].time, sorted[i].time) > Duration.ofHours(6)) {
-                        val anchorDate = subGroup.first().time.atZone(ZoneId.of("Europe/Oslo")).toLocalDate()
+                    if (Duration.between(sorted[i - 1].time, sorted[i].time) > Duration.ofHours(FlightWindowConfig.SAME_FLIGHT_GAP_HOURS)) {
+                        val anchorDate = subGroup.first().time.atZone(Dates.OSLO_ZONE).toLocalDate()
                         put(FlightKey(flightId, anchorDate), subGroup)
                         subGroup = mutableListOf()
                     }
                     subGroup.add(sorted[i])
                 }
-                val anchorDate = subGroup.first().time.atZone(ZoneId.of("Europe/Oslo")).toLocalDate()
+                val anchorDate = subGroup.first().time.atZone(Dates.OSLO_ZONE).toLocalDate()
                 put(FlightKey(flightId, anchorDate), subGroup)
             }
         }
@@ -311,12 +305,12 @@ class FlightAggregationService(
      * ongoing multi-leg flights (e.g. WF904 TOS→ALF→TOS) are retained even when their
      * first leg has already departed.
      *
-     * A chain is kept if its latest stop time is within [MAX_PAST_MINUTES] of now,
-     * and its earliest stop time is within [MAX_FUTURE_HOURS] of now.
+     * A chain is kept if its latest stop time is within [FlightWindowConfig.MAX_PAST_MINUTES] of now,
+     * and its earliest stop time is within [FlightWindowConfig.MAX_FUTURE_HOURS] of now.
      */
     private fun isChainWithinTimeWindow(flight: UnifiedFlight, now: ZonedDateTime): Boolean {
-        val minTime = now.minusMinutes(MAX_PAST_MINUTES)
-        val maxTime = now.plusHours(MAX_FUTURE_HOURS)
+        val minTime = now.minusMinutes(FlightWindowConfig.MAX_PAST_MINUTES)
+        val maxTime = now.plusHours(FlightWindowConfig.MAX_FUTURE_HOURS)
 
         val allTimes = flight.stops.flatMap { stop ->
             listOfNotNull(

--- a/src/main/kotlin/service/FlightAggregationService.kt
+++ b/src/main/kotlin/service/FlightAggregationService.kt
@@ -49,27 +49,35 @@ class FlightAggregationService(
         const val MAX_FUTURE_HOURS = 24L       // Up to 7 hours in the future
     }
 
-    /**
-     * Fetches raw flight records from the Avinor XML feed for a single airport.
-     *
-     * @param airportCode The IATA code of the airport to fetch flights for.
-     * @return The list of [Flight] records, or an empty list if the call throws exception.
-     */
-    private fun fetchFlightsForAirport(airportCode: String): List<Flight> {
-        return try {
-            val xmlResponse = avinorXmlFeedApiHandler.fetchFlights(
-                AvinorXmlFeedParamsLogic(airportCode = airportCode)
-            ).getOrElse { e ->
-                LOG.error("API call failed for {}: {}", airportCode, e.message)
-                return emptyList()
-            }
 
-            val airport = xmlHandler.unmarshallXmlToAirport(xmlResponse)
-            airport.flightsContainer?.flight ?: emptyList()
-        } catch (e: Exception) {
-            LOG.error("Error fetching data for {}: {}", airportCode, e.message)
-            emptyList()
+    /**
+     * Fetches flight data from all airports and stitches records into UnifiedFlight chains.
+     * Handles both direct (2 stops) and multi-leg (3+ stops) flights, including Svalbard routes.
+     * Used by the /siri endpoint.
+     */
+    fun buildUnifiedFlights(): List<UnifiedFlight> = runBlocking {
+        val airportCodes = AirportIATA.entries.map { it.name }
+
+        if (airportCodes.isEmpty()) {
+            LOG.error("Airport list is empty")
+            return@runBlocking emptyList()
         }
+
+        LOG.info("Starting unified flight fetch for {} airports...", airportCodes.size)
+
+        val taggedFlights = fetchTaggedFlights(airportCodes)
+        val groupedTaggedFlights = groupFlightsByIdAndDate(taggedFlights)
+
+
+        // STITCH: convert each group into an ordered chain of stops
+        val unifiedFlights = groupedTaggedFlights.mapNotNull { (key, events) ->
+            if(key.flightId == "UNKNOWN") null
+            else stitchFlightLegs(key.flightId, key.date, events)
+        }
+
+        val filteredChains = unifiedFlights.filter { isChainWithinTimeWindow(it, Dates.instantNowUtc()) }
+        LOG.info("Aggregated {} valid flight chains within time window from {} total.", filteredChains.size, unifiedFlights.size)
+        filteredChains
     }
 
     /**
@@ -118,6 +126,42 @@ class FlightAggregationService(
         return result
     }
 
+    /**
+     * Fetches raw flight records from the Avinor XML feed for a single airport.
+     *
+     * @param airportCode The IATA code of the airport to fetch flights for.
+     * @return The list of [Flight] records, or an empty list if the call throws exception.
+     */
+    private fun fetchFlightsForAirport(airportCode: String): List<Flight> {
+        return try {
+            val xmlResponse = avinorXmlFeedApiHandler.fetchFlights(
+                AvinorXmlFeedParamsLogic(airportCode = airportCode)
+            ).getOrElse { e ->
+                LOG.error("API call failed for {}: {}", airportCode, e.message)
+                return emptyList()
+            }
+
+            val airport = xmlHandler.unmarshallXmlToAirport(xmlResponse)
+            airport.flightsContainer?.flight ?: emptyList()
+        } catch (e: Exception) {
+            LOG.error("Error fetching data for {}: {}", airportCode, e.message)
+            emptyList()
+        }
+    }
+
+    /**
+     * Returns true if the flight should be treated as domestic.
+     * Svalbard ([FlightCodes.SVALBARD_AIRPORTS]) routes are classified as international by Avinor
+     * but are included because they are operated as domestic flights.
+     *
+     * @param sourceAirport The airport the flight record was fetched from.
+     * @param flight The raw Avinor flight record.
+     */
+    private fun isDomesticOrSvalbard(sourceAirport: String, flight: Flight): Boolean {
+        if (flight.domInt == FlightCodes.DOMESTIC_CODE) return true
+        return sourceAirport == FlightCodes.SVALBARD_AIRPORTS || flight.airport == FlightCodes.SVALBARD_AIRPORTS
+    }
+
     /** GROUP: by flightId, then split on gaps > 6 hours to separate consecutive-day flights
     with the same ID. Use the Oslo date of the first event in each sub-group as the anchor,
     so legs that cross midnight Oslo (e.g. 23:50 dep → 00:10 arr) stay in the same group. */
@@ -141,49 +185,6 @@ class FlightAggregationService(
                 put(FlightKey(flightId, anchorDate), subGroup)
             }
         }
-    }
-
-
-    /**
-     * Fetches flight data from all airports and stitches records into UnifiedFlight chains.
-     * Handles both direct (2 stops) and multi-leg (3+ stops) flights, including Svalbard routes.
-     * Used by the /siri endpoint.
-     */
-    fun fetchUnifiedFlights(): List<UnifiedFlight> = runBlocking {
-        val airportCodes = AirportIATA.entries.map { it.name }
-
-        if (airportCodes.isEmpty()) {
-            LOG.error("Airport list is empty")
-            return@runBlocking emptyList()
-        }
-
-        val allTaggedFlights = mutableListOf<TaggedFlight>()
-
-        LOG.info("Starting unified flight fetch for {} airports...", airportCodes.size)
-
-
-        // STITCH: convert each group into an ordered chain of stops
-        val unifiedFlights = grouped.mapNotNull { (key, events) ->
-            if(key.flightId == "UNKNOWN") null
-            else stitchFlightLegs(key.flightId, key.date, events)
-        }
-
-        val filteredChains = unifiedFlights.filter { isChainWithinTimeWindow(it, Dates.instantNowUtc()) }
-        LOG.info("Aggregated {} valid flight chains within time window from {} total.", filteredChains.size, unifiedFlights.size)
-        filteredChains
-    }
-
-    /**
-     * Returns true if the flight should be treated as domestic.
-     * Svalbard ([FlightCodes.SVALBARD_AIRPORTS]) routes are classified as international by Avinor
-     * but are included because they are operated as domestic flights.
-     *
-     * @param sourceAirport The airport the flight record was fetched from.
-     * @param flight The raw Avinor flight record.
-     */
-    private fun isDomesticOrSvalbard(sourceAirport: String, flight: Flight): Boolean {
-        if (flight.domInt == FlightCodes.DOMESTIC_CODE) return true
-        return sourceAirport == FlightCodes.SVALBARD_AIRPORTS || flight.airport == FlightCodes.SVALBARD_AIRPORTS
     }
 
     /**

--- a/src/main/kotlin/subscription/SubscriptionManager.kt
+++ b/src/main/kotlin/subscription/SubscriptionManager.kt
@@ -81,7 +81,7 @@ class SubscriptionManager(
 
         val initialDelivery: Siri? = when (subscription.subscriptionType) {
             SiriDataType.ESTIMATED_TIMETABLE -> {
-                val initialData = flightAggregationService.fetchUnifiedFlights()
+                val initialData = flightAggregationService.buildUnifiedFlights()
                 val resolvedInitialData = serviceJourneyResolver.resolve(initialData)
                 flightStateCache.populateCache(resolvedInitialData)
                 siriETMapper.mapUnifiedFlightsToSiri(resolvedInitialData)

--- a/src/main/kotlin/subscription/service/AvinorPollingService.kt
+++ b/src/main/kotlin/subscription/service/AvinorPollingService.kt
@@ -36,7 +36,7 @@ class AvinorPollingService(
         LOG.info("Starting poll cycle. Cache size: {}", flightStateCache.getCacheSize())
 
         try {
-            val allFlights = flightAggregationService.fetchUnifiedFlights()
+            val allFlights = flightAggregationService.buildUnifiedFlights()
             LOG.info("Fetched {} flights", allFlights.size)
             // Cleaning cache before filtering to avoid removing entries that were just added.
             flightStateCache.cleanCache(allFlights.map { flightStateCache.cacheKey(it) }.toSet())

--- a/src/main/kotlin/util/constants.kt
+++ b/src/main/kotlin/util/constants.kt
@@ -20,6 +20,12 @@ object PollingConfig {
     const val REQUEST_DELAY_MS = 50
 }
 
+object FlightWindowConfig {
+    const val MAX_PAST_MINUTES = 20L     // At most 20 minutes in the past
+    const val MAX_FUTURE_HOURS = 24L     // Up to 24 hours in the future
+    const val SAME_FLIGHT_GAP_HOURS = 6L // Gap threshold for splitting same-ID flights across days
+}
+
 object FlightCodes {
     //[Direction] from Avinor
     const val DEPARTURE_CODE = "D"
@@ -52,7 +58,7 @@ object FindServiceJourneyPaths {
 }
 
 object TiamatImportPaths {
-    val LOCAL_BASEPATH = "src/main/resources/stopPlaceData" //TODO THIS ONE IS PLACEHOLDER
+    val LOCAL_BASEPATH = "src/main/resources/stopPlaceData"
     val CLOUD_BASEPATH = "/tmp/stop_place_data"
 }
 
@@ -73,6 +79,7 @@ object ServiceJourneyModel {
 
 object Dates {
     val LOCALE = Locale.ENGLISH
+    val OSLO_ZONE: ZoneId = ZoneId.of("Europe/Oslo")
 
     val formats = mapOf<String, DateTimeFormatter>(
         "MMMM_dd_yyyy" to DateTimeFormatter.ofPattern("MMMM dd, yyyy", LOCALE),
@@ -81,11 +88,11 @@ object Dates {
 
     fun currentDateMMMddyyyy() = LocalDate.now().format(formats["MMMM_dd_yyyy"])
     fun instantNowUtc(): ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC)
-    fun instantNowSystemDefault(): ZonedDateTime = Instant.now().atZone(ZoneId.of("Europe/Oslo"))
+    fun instantNowSystemDefault(): ZonedDateTime = Instant.now().atZone(OSLO_ZONE)
 
 
     fun daytypeBuilder(zoneDateTime: ZonedDateTime): String{
-        val norwayZone = ZoneId.of("Europe/Oslo")
+        val norwayZone = OSLO_ZONE
 
         val norwayDateTimeDeparture = zoneDateTime .withZoneSameInstant(norwayZone)
 

--- a/src/test/kotlin/service/FlightAggregationServiceTest.kt
+++ b/src/test/kotlin/service/FlightAggregationServiceTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import model.xmlFeedApi.*
 import org.gibil.util.Dates
+import org.gibil.util.FlightWindowConfig
 import org.gibil.routes.avinor.xmlfeed.AvinorXmlFeedApiHandler
 import org.gibil.routes.avinor.xmlfeed.AvinorXmlFeedParamsLogic
 import org.junit.jupiter.api.*
@@ -391,7 +392,7 @@ class FlightAggregationServiceTest {
                 scheduleTime = now.plusMinutes(40).format(DateTimeFormatter.ISO_DATE_TIME)
             )
 
-            val staleStatus = now.minusMinutes(FlightAggregationService.MAX_PAST_MINUTES + 2)
+            val staleStatus = now.minusMinutes(FlightWindowConfig.MAX_PAST_MINUTES + 2)
                 .format(DateTimeFormatter.ISO_DATE_TIME)
             // Status times represent the latest real-world event and are used for the "too old" check.
             dep.status = FlightStatus().apply {

--- a/src/test/kotlin/service/FlightAggregationServiceTest.kt
+++ b/src/test/kotlin/service/FlightAggregationServiceTest.kt
@@ -90,7 +90,7 @@ class FlightAggregationServiceTest {
     }
 
     @Nested
-    inner class FetchUnifiedFlights {
+    inner class BuildUnifiedFlights {
 
         @Test
         fun `should stitch direct flight into 2 stops`() = runBlocking {
@@ -110,7 +110,7 @@ class FlightAggregationServiceTest {
             mockAirportData("OSL", listOf(oslDep))
             mockAirportData("BGO", listOf(bgoArr))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertEquals(1, result.size)
             val flight = result.first()
@@ -153,7 +153,7 @@ class FlightAggregationServiceTest {
             mockAirportData("BOO", listOf(booArr, booDep))
             mockAirportData("SVJ", listOf(svjArr))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertEquals(1, result.size)
             val flight = result.first()
@@ -204,7 +204,7 @@ class FlightAggregationServiceTest {
             mockAirportData("RET", listOf(retArr, retDep))
             mockAirportData("LKN", listOf(lknArr, lknDep))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertEquals(1, result.size)
             val flight = result.first()
@@ -236,7 +236,7 @@ class FlightAggregationServiceTest {
             mockAirportData("OSL", listOf(oslDep))
             mockAirportData("TRD", listOf(trdArr))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertFalse(result.any { it.flightId == "DY999" })
         }
@@ -253,7 +253,7 @@ class FlightAggregationServiceTest {
 
             mockAirportData("OSL", listOf(oslDep))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertFalse(result.any { it.flightId == "DY200" })
         }
@@ -270,7 +270,7 @@ class FlightAggregationServiceTest {
 
             mockAirportData("BGO", listOf(bgoArr))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertFalse(result.any { it.flightId == "DY300" })
         }
@@ -301,7 +301,7 @@ class FlightAggregationServiceTest {
             mockAirportData("OSL", listOf(domesticFlight, internationalFlight))
             mockAirportData("BGO", listOf(domesticArrival))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertTrue(result.any { it.flightId == "DY123" })
             assertFalse(result.any { it.flightId == "DY456" })
@@ -327,7 +327,7 @@ class FlightAggregationServiceTest {
             mockAirportData("OSL", listOf(oslDep))
             mockAirportData("LYR", listOf(lyrArr))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertTrue(result.any { it.flightId == "DY660" })
         }
@@ -368,7 +368,7 @@ class FlightAggregationServiceTest {
             mockAirportData("OSL", listOf(tooOldDep, tooFarDep))
             mockAirportData("BGO", listOf(tooOldArr, tooFarArr))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertFalse(result.any { it.flightId == "DY111" })
             assertFalse(result.any { it.flightId == "DY222" })
@@ -406,7 +406,7 @@ class FlightAggregationServiceTest {
             mockAirportData("OSL", listOf(dep))
             mockAirportData("BGO", listOf(arr))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertFalse(result.any { it.flightId == "DY333" })
         }
@@ -415,7 +415,7 @@ class FlightAggregationServiceTest {
         fun `should handle API errors gracefully`() = runBlocking {
             every { avinorXmlFeedApiHandler.fetchFlights(any()) } returns Result.failure(IOException("API unavailable"))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertEquals(0, result.size)
         }
@@ -424,7 +424,7 @@ class FlightAggregationServiceTest {
         fun `should handle exception thrown during airport data fetch`() = runBlocking {
             every { avinorXmlFeedApiHandler.fetchFlights(any()) } throws RuntimeException("Connection timeout")
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertEquals(0, result.size)
         }
@@ -443,7 +443,7 @@ class FlightAggregationServiceTest {
 
             mockAirportData("OSL", listOf(nullIdFlight))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertEquals(0, result.size)
         }
@@ -459,7 +459,7 @@ class FlightAggregationServiceTest {
 
             mockAirportData("OSL", listOf(shortIdFlight))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertEquals(0, result.size)
         }
@@ -483,7 +483,7 @@ class FlightAggregationServiceTest {
             mockAirportData("LYR", listOf(lyrDep))
             mockAirportData("OSL", listOf(oslArr))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertTrue(result.any { it.flightId == "DY661" })
         }
@@ -498,7 +498,7 @@ class FlightAggregationServiceTest {
 
             mockAirportData("OSL", listOf(nullTimeFlight))
 
-            val result = flightAggregationService.fetchUnifiedFlights()
+            val result = flightAggregationService.buildUnifiedFlights()
 
             assertFalse(result.any { it.flightId == "DY400" })
         }

--- a/src/test/kotlin/subscription/SubscriptionManagerTest.kt
+++ b/src/test/kotlin/subscription/SubscriptionManagerTest.kt
@@ -36,7 +36,7 @@ class SubscriptionManagerTest {
         serviceJourneyResolver = mockk()
         subscriptionManager = SubscriptionManager(subscriptionHttpHelper, siriETMapper, flightAggregationService, flightStateCache, serviceJourneyResolver)
 
-        every { flightAggregationService.fetchUnifiedFlights() } returns emptyList()
+        every { flightAggregationService.buildUnifiedFlights() } returns emptyList()
         every { serviceJourneyResolver.resolve(any()) } returns emptyList()
         every { siriETMapper.mapUnifiedFlightsToSiri(any()) } returns createSiriWithET()
         coEvery { subscriptionHttpHelper.postData(any(), any()) } returns 200

--- a/src/test/kotlin/subscription/service/AvinorPollingServiceTest.kt
+++ b/src/test/kotlin/subscription/service/AvinorPollingServiceTest.kt
@@ -52,7 +52,7 @@ class AvinorPollingServiceTest {
         val flights = listOf(ServiceTestHelper.mockFlight("WF844", "2026-02-26"))
         val siriPayload = mockk<Siri>()
 
-        every { flightAggregationService.fetchUnifiedFlights() } returns flights
+        every { flightAggregationService.buildUnifiedFlights() } returns flights
         every { flightStateCache.filterChanged(flights) } returns flights
         every { siriETMapper.mapUnifiedFlightsToSiri(flights) } returns siriPayload
         every { subscriptionManager.pushSiriToSubscribers(siriPayload) } just Runs
@@ -67,7 +67,7 @@ class AvinorPollingServiceTest {
     fun `should not push when no changes are detected`() {
         val flights = listOf(ServiceTestHelper.mockFlight("WF844", "2026-02-26"))
 
-        every { flightAggregationService.fetchUnifiedFlights() } returns flights
+        every { flightAggregationService.buildUnifiedFlights() } returns flights
         every { flightStateCache.filterChanged(flights) } returns emptyList()
 
         service.pollAndPushUpdates()
@@ -80,7 +80,7 @@ class AvinorPollingServiceTest {
     fun `should clean cache before filtering`() {
         val flights = listOf(ServiceTestHelper.mockFlight("WF844", "2026-02-26"))
 
-        every { flightAggregationService.fetchUnifiedFlights() } returns flights
+        every { flightAggregationService.buildUnifiedFlights() } returns flights
         every { flightStateCache.filterChanged(flights) } returns emptyList()
 
         service.pollAndPushUpdates()
@@ -96,7 +96,7 @@ class AvinorPollingServiceTest {
         val flight = ServiceTestHelper.mockFlight("WF844", "2026-02-26")
         val flights = listOf(flight)
 
-        every { flightAggregationService.fetchUnifiedFlights() } returns flights
+        every { flightAggregationService.buildUnifiedFlights() } returns flights
         every { flightStateCache.filterChanged(flights) } returns emptyList()
 
         service.pollAndPushUpdates()
@@ -106,14 +106,14 @@ class AvinorPollingServiceTest {
 
     @Test
     fun `should not throw when fetchUnifiedFlights throws`() {
-        every { flightAggregationService.fetchUnifiedFlights() } throws RuntimeException("API down")
+        every { flightAggregationService.buildUnifiedFlights() } throws RuntimeException("API down")
 
         assertDoesNotThrow { service.pollAndPushUpdates() }
     }
 
     @Test
     fun `should not push when fetchUnifiedFlights throws`() {
-        every { flightAggregationService.fetchUnifiedFlights() } throws RuntimeException("API down")
+        every { flightAggregationService.buildUnifiedFlights() } throws RuntimeException("API down")
 
         service.pollAndPushUpdates()
 
@@ -122,7 +122,7 @@ class AvinorPollingServiceTest {
 
     @Test
     fun `should handle empty flight list without pushing`() {
-        every { flightAggregationService.fetchUnifiedFlights() } returns emptyList()
+        every { flightAggregationService.buildUnifiedFlights() } returns emptyList()
         every { flightStateCache.filterChanged(emptyList()) } returns emptyList()
 
         service.pollAndPushUpdates()
@@ -138,7 +138,7 @@ class AvinorPollingServiceTest {
         val allFlights = listOf(unchanged, changed)
         val siriPayload = mockk<Siri>()
 
-        every { flightAggregationService.fetchUnifiedFlights() } returns allFlights
+        every { flightAggregationService.buildUnifiedFlights() } returns allFlights
         every { flightStateCache.filterChanged(allFlights) } returns listOf(changed)
         every { siriETMapper.mapUnifiedFlightsToSiri(listOf(changed)) } returns siriPayload
         every { subscriptionManager.pushSiriToSubscribers(siriPayload) } just Runs


### PR DESCRIPTION
…of over 6 hours to separate flights with same flightID over multiple days. Uses the earliest date as anchor allowing over midnight flights to not be dropped